### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:alpine3.13
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+RUN npm install
+# If you are building your code for production
+# RUN npm ci --only=production
+
+# Bundle app source
+COPY . .
+
+EXPOSE 8000
+CMD [ "npm", "start" ]


### PR DESCRIPTION
Hi,

EmulsiV helps me a lot in learning RISC-V. Thanks a lot for your efforts in the project.

This PR adds a Dockerfile so that it can be deployed in a single command:

```
docker build -t wuhanstudio/emulsiv .
docker run -p 8000:8000 wuhanstudio/emulsiv
```
For a small demonstration, it's deployed here in a docker swarm:

https://emulsiv.wuhanstudio.cc

Han